### PR TITLE
Lock package to 1.0.3 (desired behavior for me, but potentially a bug)

### DIFF
--- a/apps/mobile-rn/package.json
+++ b/apps/mobile-rn/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jennysharps/mobile-components": "workspace:*",
+    "@jennysharps/mobile-components": "1.0.3",
     "react-native-paper": "~4.12.1",
     "react-native-vector-icons": "^9.1.0",
     "react-native": "^0.67.3",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
       '@babel/preset-env': ^7.17.10
       '@babel/runtime': ^7.17.7
       '@callstack/repack': ^2.5.2
-      '@jennysharps/mobile-components': workspace:*
+      '@jennysharps/mobile-components': 1.0.3
       '@react-native-community/cli': ^7.0.3
       '@react-native-community/cli-platform-android': ^7.0.1
       '@react-native-community/cli-platform-ios': ^7.0.1
@@ -39,7 +39,7 @@ importers:
       typescript: ^4.6.2
       webpack: ^5.70.0
     dependencies:
-      '@jennysharps/mobile-components': link:../../libs/mobile-components
+      '@jennysharps/mobile-components': 1.0.3_b50dd7e3ae15045903644b317ce74f52
       react: 17.0.2
       react-native: 0.67.4_e790ad7392546dbbcfe0cdb89b299aa0
       react-native-paper: 4.12.1_ebfae97d888ac2cb3aad0f362471545e
@@ -1543,6 +1543,18 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
     dev: true
+
+  /@jennysharps/mobile-components/1.0.3_b50dd7e3ae15045903644b317ce74f52:
+    resolution: {integrity: sha512-PINGSIELoSTpIddW7O3JiNk25omLzHPyZAxvmJHzMPuLJy8AuEX1fBVfZO9o9bOC5piZ+XYEWyQDRvr2jlfXGg==}
+    peerDependencies:
+      '@babel/core': ^7.17.10
+      react: ^17.0.2
+      react-native: ^0.67.3
+    dependencies:
+      '@babel/core': 7.17.10
+      react: 17.0.2
+      react-native: 0.67.4_e790ad7392546dbbcfe0cdb89b299aa0
+    dev: false
 
   /@jest/console/26.6.2:
     resolution: {integrity: sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "629403c1752bedf3e09c1cebfc666f9077a3fa6d",
+  "pnpmShrinkwrapHash": "9f3fec9f3775af6868154f67b78f172124af6ae6",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }


### PR DESCRIPTION
This branch is a repro of how Rush handled locking a dependency version which happens to be have a match in the workspace.  `rush update` succeeds and the lockfile is updated as expected (or at least as I expected originally...).

## Context
We work in a monorepo and have a requirement to enable moving freely between **consuming packages from the workspace** and **consuming those same packages from artifactory** after we've published them.  Ideally, we would be able to control this by being explicit with versions in our package.json.

pnpm workspaces provides a flag to enable exactly what our preferred behavior is. See https://pnpm.io/workspaces#workspace-protocol-workspace and https://pnpm.io/workspaces#link-workspace-packages for detail.  We would like to force the behavior of `link-workspace-packages=false` in our monorepo to enable our proposed developer & CI workflows.

Next PR: https://github.com/jennysharps/rush-js-spike/pull/8