### PR TITLE
Lock package to 1.0.2 (fails)

### DIFF
--- a/apps/mobile-rn/package.json
+++ b/apps/mobile-rn/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jennysharps/mobile-components": "workspace:*",
+    "@jennysharps/mobile-components": "1.0.2",
     "react-native-paper": "~4.12.1",
     "react-native-vector-icons": "^9.1.0",
     "react-native": "^0.67.3",


### PR DESCRIPTION
This branch is a repro of how Rush handled locking a dependency version which happens to not match any package in the workspace (both by name & version). rush update fails with:

`"@jennysharps/mobile-rn" depends on package "@jennysharps/mobile-components" (1.0.2) which exists within the workspace but cannot be fulfilled with the specified version range. Either specify a valid version range, or add the package as a cyclic dependency.`

For context, see https://github.com/jennysharps/rush-js-spike/pull/7

![Screenshot 2022-05-06 at 21 12 57](https://user-images.githubusercontent.com/1467161/167210317-fab87215-d802-423c-8c21-22de8e4f07e9.png)

Next PR: https://github.com/jennysharps/rush-js-spike/pull/9