### PR TITLE
Lock package to 1.0.2 & add to cyclic dependency projects (succeeds)

### DIFF
--- a/apps/mobile-rn/package.json
+++ b/apps/mobile-rn/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@jennysharps/mobile-components": "workspace:*",
+    "@jennysharps/mobile-components": "1.0.2",
     "react-native-paper": "~4.12.1",
     "react-native-vector-icons": "^9.1.0",
     "react-native": "^0.67.3",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11,7 +11,7 @@ importers:
       '@babel/preset-env': ^7.17.10
       '@babel/runtime': ^7.17.7
       '@callstack/repack': ^2.5.2
-      '@jennysharps/mobile-components': workspace:*
+      '@jennysharps/mobile-components': 1.0.2
       '@react-native-community/cli': ^7.0.3
       '@react-native-community/cli-platform-android': ^7.0.1
       '@react-native-community/cli-platform-ios': ^7.0.1
@@ -39,7 +39,7 @@ importers:
       typescript: ^4.6.2
       webpack: ^5.70.0
     dependencies:
-      '@jennysharps/mobile-components': link:../../libs/mobile-components
+      '@jennysharps/mobile-components': 1.0.2_b50dd7e3ae15045903644b317ce74f52
       react: 17.0.2
       react-native: 0.67.4_e790ad7392546dbbcfe0cdb89b299aa0
       react-native-paper: 4.12.1_ebfae97d888ac2cb3aad0f362471545e
@@ -1543,6 +1543,18 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
     dev: true
+
+  /@jennysharps/mobile-components/1.0.2_b50dd7e3ae15045903644b317ce74f52:
+    resolution: {integrity: sha512-HfGtc4Z4/CaY1vV3iidUTvKw7zcp9cBXLG1KTa4e6vXZ41bZpSb9eFiizvq1we7TYxJHSTxzvvdNCVgjoLI1Ng==}
+    peerDependencies:
+      '@babel/core': ^7.17.10
+      react: ^17.0.2
+      react-native: ^0.67.3
+    dependencies:
+      '@babel/core': 7.17.10
+      react: 17.0.2
+      react-native: 0.67.4_e790ad7392546dbbcfe0cdb89b299aa0
+    dev: false
 
   /@jest/console/26.6.2:
     resolution: {integrity: sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "629403c1752bedf3e09c1cebfc666f9077a3fa6d",
+  "pnpmShrinkwrapHash": "04a9f2ec8e72db1f35f03ba9d90eecccec89d5e3",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/rush.json
+++ b/rush.json
@@ -466,7 +466,8 @@
     {
       "packageName": "@jennysharps/mobile-rn",
       "projectFolder": "apps/mobile-rn",
-      "shouldPublish": false
+      "shouldPublish": false,
+      "cyclicDependencyProjects": ["@jennysharps/mobile-components"]
     },
     {
       "packageName": "@jennysharps/mobile-components",


### PR DESCRIPTION
This branch is a repro of how Rush handled locking a dependency version which happens to not be satisfied by the package of the same name in the workspace.  After adding the package to `cyclicDependencyProjects`, `rush update` succeeds!

For context, see https://github.com/jennysharps/rush-js-spike/pull/7 & https://github.com/jennysharps/rush-js-spike/pull/8

### The part I'm confused about

So in addition to removing the `workspace:` protocol, we'd have to add the project to `cyclicDependencyProjects` to lock it to an older npm version.  This doesn't seem horrible, but also isn't really ideal as there becomes a new thing to keep in sync.

Furthermore, the behavior in https://github.com/jennysharps/rush-js-spike/pull/7 definitely starts to feel more like a bug. Why do we not have to add the project to cyclic dependencies until the package in the workspace happens to have been bumped out of range, even though it's not being linked to begin with?

Also, and this can be a repro for another time, but I'm fairly certain that these locked versions will get bumped by `rush version --bump` whenever the monorepo package gets bumped again -- so the locked behavior will be automatically unlocked (by CI in our case), and we'll be potentially attempting to publish something we couldn't reproduce locally until we ran `rush version --bump`.  (I'm not sure if adding the project to cyclic dependency projects has any affect on this part though). Update: there is is a very similar topic of conversation where the versioning issues I'm trying to get at are described in changesets https://github.com/changesets/changesets/issues/664